### PR TITLE
add safe check,in case virtualRenderer is undefined

### DIFF
--- a/src/recyclerlistview/RecyclerListView.js
+++ b/src/recyclerlistview/RecyclerListView.js
@@ -82,6 +82,9 @@ class RecyclerListView extends Component {
     }
 
     componentWillReceiveProps(newProps) {
+        if(!this._initComplete){
+            return
+        }
         this._assertDependencyPresence(newProps);
         this._checkAndChangeLayouts(newProps);
         if (!this.props.onVisibleIndexesChanged) {
@@ -94,6 +97,9 @@ class RecyclerListView extends Component {
 
 
     componentDidUpdate() {
+        if(!this._initComplete){
+            return
+        }
         if (this._pendingScrollToOffset) {
             let offset = this._pendingScrollToOffset;
             this._pendingScrollToOffset = null;

--- a/src/recyclerlistview/RecyclerListView.js
+++ b/src/recyclerlistview/RecyclerListView.js
@@ -152,6 +152,9 @@ class RecyclerListView extends Component {
                 this.props.contextProvider.remove(uniqueKey);
             }
         }
+        if(this.props.containerLayout){
+            this._onSizeChanged(this.props.containerLayout)
+        }
     }
 
     scrollToIndex(index, animate) {

--- a/src/recyclerlistview/scrollcomponent/reactnative/ScrollComponent.js
+++ b/src/recyclerlistview/scrollcomponent/reactnative/ScrollComponent.js
@@ -44,7 +44,7 @@ class ScrollComponent extends React.Component {
                         {...this.props}
                         horizontal={this.props.isHorizontal}
                         onScroll={this._onScroll}
-                        onLayout={(!this._isSizeChangedCalledOnce || this.props.canChangeSize) ? this._onLayout : null}>
+                        onLayout={ !this.props.containerLayout && (!this._isSizeChangedCalledOnce || this.props.canChangeSize) ? this._onLayout : null}>
                 <View style={{flexDirection: this.props.isHorizontal ? 'row' : 'column'}}>
                     <View style={{
                         height: this.props.contentHeight,


### PR DESCRIPTION
when parent component' props change and _onSizeChanged hasn't called, virtualRenderer is undefined and there throws en exception